### PR TITLE
specify sysadmin user to Check, Upload and Push

### DIFF
--- a/roles/manage_provision_entities/tasks/main.yml
+++ b/roles/manage_provision_entities/tasks/main.yml
@@ -28,8 +28,8 @@
     url: "https://manage.{{ base_domain }}/manage/api/internal/search/{{ manage_search_path }}"
     body_format: json
     method: POST
-    user: "{{ manage.apiUsers[2].name }}"
-    password: "{{ manage.apiUsers[2].password }}"
+    user: "sysadmin"
+    password: "{{ manage_sysadmin_secret }}"
     force_basic_auth: yes
     body:
       entityid: "{{ manage_provision_client_id }}"
@@ -44,8 +44,8 @@
     url: "https://manage.{{ base_domain }}/manage/api/internal/metadata"
     body_format: json
     method: POST
-    user: "{{ manage.apiUsers[2].name }}"
-    password: "{{ manage.apiUsers[2].password }}"
+    user: "sysadmin"
+    password: "{{ manage_sysadmin_secret }}"
     force_basic_auth: yes
     body: "{{ lookup('template', './{{ entity_type }}.j2') }}"
   run_once: true
@@ -57,8 +57,8 @@
   uri:
     url: "https://manage.{{ base_domain }}/manage/api/internal/push"
     method: GET
-    user: "{{ manage.apiUsers[2].name }}" 
-    password: "{{ manage.apiUsers[2].password }}" 
+    user: "sysadmin"
+    password: "{{ manage_sysadmin_secret }}"
     force_basic_auth: yes
     status_code: 200
   run_once: true


### PR DESCRIPTION
We add some issues on this role when installing Voot. In our case Ansible was trying to Upload the entity to Manage using the user "sysadmin" but the user was "stats" that we add in the past for the statistics user to get access to Manage. On that role the order of manage.apiUsers variable matters. On our case the variables order on manage.apiUsers was different. The third item "[2]" on the array was not "sysadmin", but "stats". To avoid to miss the correct user to do that operation on that role, we suggest to specify the user and get directly his password